### PR TITLE
Safe user data

### DIFF
--- a/lib/omniauth-ihealth/version.rb
+++ b/lib/omniauth-ihealth/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module IHealth
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
   end
 end

--- a/lib/omniauth/strategies/ihealth.rb
+++ b/lib/omniauth/strategies/ihealth.rb
@@ -76,6 +76,7 @@ module OmniAuth
           user_data[:weight]   = calc_weight(info["weight"], info["WeightUnit"]) if info["weight"] && info["WeightUnit"]
           user_data[:birthday] = Time.at(info["dateofbirth"]).to_date.strftime("%Y-%m-%d") if info["dateofbirth"]
         end
+        user_data
       end
 
       protected

--- a/lib/omniauth/strategies/ihealth.rb
+++ b/lib/omniauth/strategies/ihealth.rb
@@ -66,15 +66,16 @@ module OmniAuth
 
       def user_data
         info = raw_info
-        user_data ||= {
-          :name => info["nickname"],
-          :gender => info["gender"].downcase,
-          :birthday => Time.at(info["dateofbirth"]).to_date.strftime("%Y-%m-%d"),
-          :image => URI.unescape(info["logo"]),
-          :nickname => info["nickname"],
-          :height => calc_height(info["height"], info["HeightUnit"]),
-          :weight => calc_weight(info["weight"], info["WeightUnit"])
-        }
+        if !user_data
+          user_data = {}
+          user_data[:name]     = info["nickname"]           if info["nickname"]
+          user_data[:nickname] = info["nickname"]           if info["nickname"]
+          user_data[:gender]   = info["gender"]             if info["gender"]
+          user_data[:image]    = URI.unescape(info["logo"]) if info["logo"]
+          user_data[:height]   = calc_height(info["height"], info["HeightUnit"]) if info["height"] && info["HeightUnit"]
+          user_data[:weight]   = calc_weight(info["weight"], info["WeightUnit"]) if info["weight"] && info["WeightUnit"]
+          user_data[:birthday] = Time.at(info["dateofbirth"]).to_date.strftime("%Y-%m-%d") if info["dateofbirth"]
+        end
       end
 
       protected


### PR DESCRIPTION
Addresses #3 by ensuring field exists in iHealth API response hash before attempting assignment.

This is just a fix of the specific bug reported, and does **not** necessarily work with the most recent version of the iHealth API.
